### PR TITLE
httpstan 4.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,8 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: HTTP-based REST interface to Stan, a package for Bayesian inference.
+  description: |
+    httpstan is a shim allowing clients able to make HTTP-based requests to call functions in the Stan C++ library’s stan::services namespace. httpstan was originally developed as a “backend” for a Stan interface written in Python, PyStan.
   doc_url: https://httpstan.readthedocs.io/
   dev_url: https://github.com/stan-dev/httpstan
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,20 +25,23 @@ requirements:
     - poetry-core >=1.0.0
     - pybind11  >=2.9.2
     - python
-    - setuptools >=48.0
+    - setuptools
   run:
     - python
     - aiohttp  >=3.7
     - appdirs  >=1.4
     - marshmallow  >=3.10
     - numpy  >=1.19
-    - setuptools  >=41.0
     - webargs  >=8.0
 
 test:
   imports:
     - httpstan
     - httpstan.services
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://pypi.org/project/httpstan/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,11 +28,12 @@ requirements:
     - setuptools
   run:
     - python
-    - aiohttp  >=3.7
-    - appdirs  >=1.4
-    - marshmallow  >=3.10
+    - aiohttp  >=3.7,<4.0
+    - appdirs  >=1.4,<2.0
+    - marshmallow  >=3.10,<4.0
     - numpy  >=1.19
-    - webargs  >=8.0
+    - webargs  >=8.0,<9.0
+    - setuptools >=48.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6b15a07557715e79e6fd66993930003b270f8b8b0c9e65f84978afe5e6bb3047
 
 build:
-  number: 3
+  number: 0
   script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
   skip: True  # [py<310]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,14 +16,9 @@ build:
 
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - {{ compiler('cxx') }}
   host:
     - pip
     - poetry-core >=1.0.0
-    - pybind11  >=2.9.2
     - python
     - setuptools
   run:
@@ -46,8 +41,8 @@ test:
 
 about:
   home: https://pypi.org/project/httpstan/
-  license: BSD-2-Clause
-  license_family: BSD
+  license: ISC
+  license_family: Other
   license_file: LICENSE
   summary: HTTP-based REST interface to Stan, a package for Bayesian inference.
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "httpstan" %}
-{% set version = "4.6.1" %}
+{% set version = "4.13.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,34 +7,33 @@ package:
 
 source:
   url: https://github.com/stan-dev/httpstan/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 703e5e04e60651e0004574bb9695827d759fd13eb0d6bd67f827c1bfa0a1fd31
+  sha256: 6b15a07557715e79e6fd66993930003b270f8b8b0c9e65f84978afe5e6bb3047
 
 build:
   number: 3
   script: "{{ PYTHON }} -m pip install . -vv"
-  skip: True  # [py<37] 
-  
+  skip: True  # [py<310]
+
 
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - pybind11                               # [build_platform != target_platform]
     - {{ compiler('cxx') }}
   host:
     - pip
-    - poetry  >=1.1.4
-    - pybind11  >=2.6.2
+    - poetry-core >=1.0.0
+    - pybind11  >=2.9.2
     - python
+    - setuptools >=48.0
   run:
+    - python
     - aiohttp  >=3.7
     - appdirs  >=1.4
-    - lz4  >=3.1
     - marshmallow  >=3.10
-    - numpy  >=1.16
-    - python
+    - numpy  >=1.19
     - setuptools  >=41.0
-    - webargs  >=7.0
+    - webargs  >=8.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 3
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
   skip: True  # [py<310]
 
 


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-8119](https://anaconda.atlassian.net/browse/PKG-8119) 
- [Upstream repository](https://github.com/stan-dev/httpstan/tree/4.13.0)
- Relevant dependency PRs:
  - `httpstan` ➡️  `pystan`

### Explanation of changes:

- Update version and sha
- Update python build skip
- Update dependencies
- Add pip check
- Linter fixes


[PKG-8119]: https://anaconda.atlassian.net/browse/PKG-8119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ